### PR TITLE
Activate linker flow in end_of_run workflow

### DIFF
--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -1,5 +1,6 @@
 from prefect import task, flow, get_run_logger
 from data_validation import data_validation
+from linker import linker
 
 
 @task
@@ -12,4 +13,5 @@ def log_completion():
 def end_of_run_workflow(stop_doc):
     uid = stop_doc["run_start"]
     data_validation(uid)
+    linker(uid)
     log_completion()


### PR DESCRIPTION
This PR enables the linker flow inside the end_of_run workflow. This step enables the linker flow to be run at the beamline automatically.