### PR TITLE
adding primary stream references to sample_name is enabled

### DIFF
--- a/linker.py
+++ b/linker.py
@@ -81,7 +81,6 @@ def get_symlink_pairs(ref, *, det_map, root_map=None):
 
     links = []
     target_template: str
-    sample_name: str
     output_path: str
     resource_info = {}
     datum_info = {}
@@ -93,8 +92,7 @@ def get_symlink_pairs(ref, *, det_map, root_map=None):
     for name, doc in hrf.documents():
         if name == "start":
             start_uid = doc["uid"]
-            sample_name = doc['sample_name']
-            target_template = (f"{{det_name}}/{doc['username']}_{{sample}}_"
+            target_template = (f"{{det_name}}/{doc['username']}_{doc['sample_name']}_"
                                f"id{doc['scan_id']}_{{N:06d}}_{{det_type}}.tif")
 
             target_path = Path(
@@ -136,7 +134,7 @@ def get_symlink_pairs(ref, *, det_map, root_map=None):
             # the event level things (motor positions)
             if name == "event":
                 doc = event_model.pack_event_page(doc)
-
+            single_doc_data = {key:doc['data'][key][0] for key in doc['data']}
             for key in target_keys:
 
                 det, _, _ = key.partition("_")
@@ -162,15 +160,15 @@ def get_symlink_pairs(ref, *, det_map, root_map=None):
                                 point_number * fpp + fr,
                             )
                         )
-                        if 'target_file_name' in doc['data']:
-                            sample_name = doc['data']['target_file_name'][0]
 
+                        
                         dest_path = target_path / target_template.format(
                             det_name=det_name,
                             N=point_number * fpp + fr,
                             det_type=det_type,
-                            sample=sample_name,
-                        )
+                            **single_doc_data
+                        ).format(**single_doc_data)
+                        
                         links.append(
                             (start_uid, source_path, dest_path, analysis_path)
                         )


### PR DESCRIPTION
The sample_name portion of the filename can be generated from start['sample_name'] three ways, 

1. the start['sample_name'] can just be text , and it will be used as before

   for instance start['sample_name'] = "new_sample" results in a filename containing "new_sample"

2. the start['sample_name'] can contain a format with any valid primary stream name, including names which are strings generated within the plan like target_file_name

   for example sample_name = "{target_file_name}_x{piexo_x}" with target_file_name= "energy34eV" would result in a filename like "energy34eV_x4000"

3. the target_file_name or any other string in the primary stream itself can have formats referencing other primary streams (if the format is expected to change during a plan that might be useful)

   for example "{target_file_name}___{pil1M_stats1_total}" and target_file_name="energy34eV_{thorlabs_su_readback}mm" would together result in a filename like "energy34eV_85mm___350000"
