### PR TITLE
Dotenv dry run fromuri

### DIFF
--- a/data_validation.py
+++ b/data_validation.py
@@ -18,6 +18,7 @@ def read_stream(run, stream):
     return stream_data
 
 
+# this is a task to enable being run by a ConcurrentTaskRunner
 @task
 def read_all_streams(uid, api_key=None, dry_run=False):
     logger = get_run_logger()

--- a/data_validation.py
+++ b/data_validation.py
@@ -18,24 +18,21 @@ def read_stream(run, stream):
 
 # this is a task to enable being run by a ConcurrentTaskRunner
 @task
-def read_all_streams(uid, api_key=None, dry_run=False):
+def read_all_streams(uid, api_key=None):
     logger = get_run_logger()
-    if dry_run:
-        logger.info("Dry run: not creating Tiled client or checking streams")
-    else:
-        start_time = ttime.monotonic()
-        run = get_run(uid, api_key=api_key)
-        logger.info(f"Validating uid {uid}")
-        for stream in run:
-            logger.info(f"{stream}:")
-            stream_start_time = ttime.monotonic()
-            stream_data = read_stream(run, stream)
-            stream_elapsed_time = ttime.monotonic() - stream_start_time
-            logger.info(f"{stream} elapsed_time = {stream_elapsed_time}")
-            logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
-        elapsed_time = ttime.monotonic() - start_time
-        logger.info(f"{elapsed_time = }")
+    start_time = ttime.monotonic()
+    run = get_run(uid, api_key=api_key)
+    logger.info(f"Validating uid {uid}")
+    for stream in run:
+        logger.info(f"{stream}:")
+        stream_start_time = ttime.monotonic()
+        stream_data = read_stream(run, stream)
+        stream_elapsed_time = ttime.monotonic() - stream_start_time
+        logger.info(f"{stream} elapsed_time = {stream_elapsed_time}")
+        logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
+    elapsed_time = ttime.monotonic() - start_time
+    logger.info(f"{elapsed_time = }")
 
 @flow
-def data_validation(uid, api_key=None, dry_run=False):
-    read_all_streams(uid, api_key=api_key, dry_run=dry_run)
+def data_validation(uid, api_key=None):
+    read_all_streams(uid, api_key=api_key)

--- a/data_validation.py
+++ b/data_validation.py
@@ -7,7 +7,7 @@ from tiled.client import from_uri
 def get_run(uid, api_key=None):
     logger = get_run_logger()
     tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
-    run = tiled_client["smi"]["raw"][uid]
+    run = tiled_client["smi/raw"][uid]
     logger.info(f"Validating uid {uid}")
     return run
 

--- a/data_validation.py
+++ b/data_validation.py
@@ -4,7 +4,7 @@ from tiled.client import from_uri
 
 
 @task(retries=2, retry_delay_seconds=10)
-def get_client(uid, api_key=None):
+def get_run(uid, api_key=None):
     logger = get_run_logger()
     tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
     run = tiled_client["smi"]["raw"][uid]

--- a/data_validation.py
+++ b/data_validation.py
@@ -5,10 +5,8 @@ from tiled.client import from_uri
 
 @task(retries=2, retry_delay_seconds=10)
 def get_run(uid, api_key=None):
-    logger = get_run_logger()
     tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
     run = tiled_client["smi/raw"][uid]
-    logger.info(f"Validating uid {uid}")
     return run
 
 
@@ -27,6 +25,7 @@ def read_all_streams(uid, api_key=None, dry_run=False):
     else:
         start_time = ttime.monotonic()
         run = get_run(uid, api_key=api_key)
+        logger.info(f"Validating uid {uid}")
         for stream in run:
             logger.info(f"{stream}:")
             stream_start_time = ttime.monotonic()

--- a/data_validation.py
+++ b/data_validation.py
@@ -1,16 +1,19 @@
 from prefect import task, flow, get_run_logger
-from prefect.blocks.system import Secret
 import time as ttime
-from tiled.client import from_profile
+from tiled.client import from_uri
 
 
 @task(retries=2, retry_delay_seconds=10)
-def read_all_streams(uid, beamline_acronym):
+def get_client(uid, api_key=None):
     logger = get_run_logger()
-    api_key = Secret.load("tiled-smi-api-key", _sync=True).get()
-    tiled_client = from_profile("nsls2", api_key=api_key)
-    run = tiled_client[beamline_acronym]["raw"][uid]
+    tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
+    run = tiled_client["smi"]["raw"][uid]
     logger.info(f"Validating uid {uid}")
+    return run
+
+
+@task(retries=2, retry_delay_seconds=10)
+def read_all_streams(uid, api_key=None):
     start_time = ttime.monotonic()
     for stream in run:
         logger.info(f"{stream}:")
@@ -24,5 +27,5 @@ def read_all_streams(uid, beamline_acronym):
 
 
 @flow
-def data_validation(uid):
-    read_all_streams(uid, beamline_acronym="smi")
+def data_validation(uid, api_key=None):
+    read_all_streams(uid, api_key=api_key)

--- a/data_validation.py
+++ b/data_validation.py
@@ -19,16 +19,19 @@ def read_stream(run, stream):
 
 
 @flow
-def data_validation(uid, api_key=None):
+def data_validation(uid, api_key=None, dry_run=False):
     logger = get_run_logger()
-    start_time = ttime.monotonic()
-    run = get_client(uid, api_key=api_key)
-    for stream in run:
-        logger.info(f"{stream}:")
-        stream_start_time = ttime.monotonic()
-        stream_data = read_stream(run, stream)
-        stream_elapsed_time = ttime.monotonic() - stream_start_time
-        logger.info(f"{stream} elapsed_time = {stream_elapsed_time}")
-        logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
-    elapsed_time = ttime.monotonic() - start_time
-    logger.info(f"{elapsed_time = }")
+    if dry_run:
+        logger.info("Dry run: not creating Tiled client or checking streams")
+    else:
+        start_time = ttime.monotonic()
+        run = get_client(uid, api_key=api_key)
+        for stream in run:
+            logger.info(f"{stream}:")
+            stream_start_time = ttime.monotonic()
+            stream_data = read_stream(run, stream)
+            stream_elapsed_time = ttime.monotonic() - stream_start_time
+            logger.info(f"{stream} elapsed_time = {stream_elapsed_time}")
+            logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
+        elapsed_time = ttime.monotonic() - start_time
+        logger.info(f"{elapsed_time = }")

--- a/data_validation.py
+++ b/data_validation.py
@@ -20,7 +20,9 @@ def read_stream(run, stream):
 
 @flow
 def data_validation(uid, api_key=None):
+    logger = get_run_logger()
     start_time = ttime.monotonic()
+    run = get_client(uid, api_key=api_key)
     for stream in run:
         logger.info(f"{stream}:")
         stream_start_time = ttime.monotonic()

--- a/data_validation.py
+++ b/data_validation.py
@@ -12,20 +12,21 @@ def get_client(uid, api_key=None):
     return run
 
 
-@task(retries=2, retry_delay_seconds=10)
-def read_all_streams(uid, api_key=None):
+@task
+def read_stream(run, stream):
+    stream_data = run[stream].read()
+    return stream_data
+
+
+@flow
+def data_validation(uid, api_key=None):
     start_time = ttime.monotonic()
     for stream in run:
         logger.info(f"{stream}:")
         stream_start_time = ttime.monotonic()
-        stream_data = run[stream].read()
+        stream_data = read_stream(run, stream)
         stream_elapsed_time = ttime.monotonic() - stream_start_time
         logger.info(f"{stream} elapsed_time = {stream_elapsed_time}")
         logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
     elapsed_time = ttime.monotonic() - start_time
     logger.info(f"{elapsed_time = }")
-
-
-@flow
-def data_validation(uid, api_key=None):
-    read_all_streams(uid, api_key=api_key)

--- a/data_validation.py
+++ b/data_validation.py
@@ -26,7 +26,7 @@ def read_all_streams(uid, api_key=None, dry_run=False):
         logger.info("Dry run: not creating Tiled client or checking streams")
     else:
         start_time = ttime.monotonic()
-        run = get_client(uid, api_key=api_key)
+        run = get_run(uid, api_key=api_key)
         for stream in run:
             logger.info(f"{stream}:")
             stream_start_time = ttime.monotonic()

--- a/data_validation.py
+++ b/data_validation.py
@@ -18,8 +18,8 @@ def read_stream(run, stream):
     return stream_data
 
 
-@flow
-def data_validation(uid, api_key=None, dry_run=False):
+@task
+def read_all_streams(uid, api_key=None, dry_run=False):
     logger = get_run_logger()
     if dry_run:
         logger.info("Dry run: not creating Tiled client or checking streams")
@@ -35,3 +35,7 @@ def data_validation(uid, api_key=None, dry_run=False):
             logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
         elapsed_time = ttime.monotonic() - start_time
         logger.info(f"{elapsed_time = }")
+
+@flow
+def data_validation(uid, api_key=None, dry_run=False):
+    read_all_streams(uid, api_key=api_key, dry_run=dry_run)

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -10,14 +10,13 @@ from dotenv import load_dotenv
 
 def get_api_key_from_env(api_key=None):
     logger = get_run_logger()
-    if not api_key:
-        try:
-            with open("/srv/container.secret", "r") as secrets:
-                load_dotenv(stream=secrets)
-        except Exception:
-            logger.exception("Exception while getting Tiled API key")
-        finally:
-            api_key = os.environ["TILED_API_KEY"]
+    try:
+        with open("/srv/container.secret", "r") as secrets:
+            load_dotenv(stream=secrets)
+    except Exception:
+        logger.exception("Exception while getting Tiled API key")
+    finally:
+        api_key = os.environ["TILED_API_KEY"]
     return api_key
 
 

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -4,7 +4,7 @@ from prefect import task, flow, get_run_logger
 from prefect.task_runners import ConcurrentTaskRunner
 from data_validation import data_validation
 from linker import get_symlink_pairs
-from export import export_amptek
+from export import export_amptek, has_amptek_keys
 from dotenv import load_dotenv
 
 
@@ -41,10 +41,13 @@ def end_of_run_workflow(stop_doc, dry_run=False):
     validation_task = data_validation.submit(uid, api_key=api_key, dry_run=dry_run)
     logger.info("Launched validation task")
     export_task = None
-    if not dry_run:
+    if not dry_run and has_amptek_keys(uid, api_key=api_key):
         export_task = export_amptek.submit(uid)
         logger.info("Launched amptek export task")
-
+    elif dry_run:
+        logger.info("Dry run: skipping amptek export")
+    else:
+        logger.info("Skipping export, amptek keys not present")
     # Wait for completion.
     logger.info("Waiting for tasks to complete")
     validation_task.result()

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -2,7 +2,7 @@ import getpass
 import os
 from prefect import task, flow, get_run_logger
 from prefect.task_runners import ConcurrentTaskRunner
-from data_validation import data_validation
+from data_validation import read_all_streams
 from linker import get_symlink_pairs
 from export import export_amptek, has_amptek_keys
 from dotenv import load_dotenv
@@ -39,7 +39,7 @@ def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
     det_map = {"900KW": "WAXS", "1M": "SAXS", "2M": "SAXS2M"}
     linker_task = get_symlink_pairs.submit(uid, det_map=det_map, api_key=api_key, dry_run=dry_run)
     logger.info("Launched linker task")
-    validation_task = data_validation.submit(uid, api_key=api_key, dry_run=dry_run)
+    validation_task = read_all_streams.submit(uid, api_key=api_key, dry_run=dry_run)
     logger.info("Launched validation task")
     export_task = None
     if not dry_run and has_amptek_keys(uid, api_key=api_key):

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -2,7 +2,7 @@ import getpass
 import os
 from prefect import task, flow, get_run_logger
 from prefect.task_runners import ConcurrentTaskRunner
-from data_validation import read_all_streams
+from data_validation import data_validation
 from linker import get_symlink_pairs
 from export import export_amptek
 from dotenv import load_dotenv
@@ -38,7 +38,7 @@ def end_of_run_workflow(stop_doc):
     det_map = {"900KW": "WAXS", "1M": "SAXS", "2M": "SAXS2M"}
     linker_task = get_symlink_pairs.submit(uid, det_map=det_map, api_key=api_key)
     logger.info("Launched linker task")
-    validation_task = read_all_streams.submit(uid, api_key=api_key)
+    validation_task = data_validation.submit(uid, api_key=api_key)
     logger.info("Launched validation task")
     export_task = export_amptek.submit(uid)
     logger.info("Launched amptek export task")

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -28,7 +28,7 @@ def log_completion():
 
 
 @flow(task_runner=ConcurrentTaskRunner())
-def end_of_run_workflow(stop_doc):
+def end_of_run_workflow(stop_doc, dry_run=False):
     logger = get_run_logger()
     uid = stop_doc["run_start"]
     api_key = get_api_key_from_env(api_key=None)
@@ -36,16 +36,19 @@ def end_of_run_workflow(stop_doc):
 
     # Launch validation and linker concurrently.
     det_map = {"900KW": "WAXS", "1M": "SAXS", "2M": "SAXS2M"}
-    linker_task = get_symlink_pairs.submit(uid, det_map=det_map, api_key=api_key)
+    linker_task = get_symlink_pairs.submit(uid, det_map=det_map, api_key=api_key, dry_run=dry_run)
     logger.info("Launched linker task")
-    validation_task = data_validation.submit(uid, api_key=api_key)
+    validation_task = data_validation.submit(uid, api_key=api_key, dry_run=dry_run)
     logger.info("Launched validation task")
-    export_task = export_amptek.submit(uid)
-    logger.info("Launched amptek export task")
+    export_task = None
+    if not dry_run:
+        export_task = export_amptek.submit(uid)
+        logger.info("Launched amptek export task")
 
     # Wait for completion.
     logger.info("Waiting for tasks to complete")
     validation_task.result()
     linker_task.result()
-    export_task.result()
+    if export_task:
+        export_task.result()
     log_completion()

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -28,10 +28,11 @@ def log_completion():
 
 
 @flow(task_runner=ConcurrentTaskRunner())
-def end_of_run_workflow(stop_doc, dry_run=False):
+def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
     logger = get_run_logger()
     uid = stop_doc["run_start"]
-    api_key = get_api_key_from_env(api_key=None)
+    if not api_key:
+        api_key = get_api_key_from_env(api_key=None)
     logger.info(f"effective user: {getpass.getuser()}")
 
     # Launch validation and linker concurrently.

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -10,13 +10,9 @@ from dotenv import load_dotenv
 
 def get_api_key_from_env(api_key=None):
     logger = get_run_logger()
-    try:
-        with open("/srv/container.secret", "r") as secrets:
-            load_dotenv(stream=secrets)
-    except Exception:
-        logger.exception("Exception while getting Tiled API key")
-    finally:
-        api_key = os.environ["TILED_API_KEY"]
+    with open("/srv/container.secret", "r") as secrets:
+        load_dotenv(stream=secrets)
+    api_key = os.environ["TILED_API_KEY"]
     return api_key
 
 

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -1,9 +1,24 @@
 import getpass
+import os
 from prefect import task, flow, get_run_logger
 from prefect.task_runners import ConcurrentTaskRunner
 from data_validation import read_all_streams
 from linker import get_symlink_pairs
 from export import export_amptek
+from dotenv import load_dotenv
+
+
+def get_api_key_from_env(api_key=None):
+    logger = get_run_logger()
+    if not api_key:
+        try:
+            with open("/srv/container.secret", "r") as secrets:
+                load_dotenv(stream=secrets)
+        except Exception:
+            logger.exception("Exception while getting Tiled API key")
+        finally:
+            api_key = os.environ["TILED_API_KEY"]
+    return api_key
 
 
 @task
@@ -16,13 +31,14 @@ def log_completion():
 def end_of_run_workflow(stop_doc):
     logger = get_run_logger()
     uid = stop_doc["run_start"]
+    api_key = get_api_key_from_env(api_key=None)
     logger.info(f"effective user: {getpass.getuser()}")
 
     # Launch validation and linker concurrently.
     det_map = {"900KW": "WAXS", "1M": "SAXS", "2M": "SAXS2M"}
-    linker_task = get_symlink_pairs.submit(uid, det_map=det_map)
+    linker_task = get_symlink_pairs.submit(uid, det_map=det_map, api_key=api_key)
     logger.info("Launched linker task")
-    validation_task = read_all_streams.submit(uid, beamline_acronym="smi")
+    validation_task = read_all_streams.submit(uid, api_key=api_key)
     logger.info("Launched validation task")
     export_task = export_amptek.submit(uid)
     logger.info("Launched amptek export task")

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -34,7 +34,7 @@ def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
     det_map = {"900KW": "WAXS", "1M": "SAXS", "2M": "SAXS2M"}
     linker_task = get_symlink_pairs.submit(uid, det_map=det_map, api_key=api_key, dry_run=dry_run)
     logger.info("Launched linker task")
-    validation_task = read_all_streams.submit(uid, api_key=api_key, dry_run=dry_run)
+    validation_task = read_all_streams.submit(uid, api_key=api_key)
     logger.info("Launched validation task")
     export_task = None
     if not dry_run and has_amptek_keys(uid, api_key=api_key):

--- a/export.py
+++ b/export.py
@@ -13,6 +13,12 @@ def get_run(uid, api_key=None):
 
 
 @task
+def has_amptek_keys(uid, api_key=None):
+    run = get_run(uid, api_key=api_key)
+    return ("amptek_energy_channels", "amptek_mca_spectrum") in run.primary.data
+
+
+@task
 def export_amptek(ref, api_key=None):
     """
     Parameters
@@ -32,7 +38,7 @@ def export_amptek(ref, api_key=None):
 
     run = get_run(ref, api_key=api_key)
 
-    if "amptek_energy_channels" in run.primary.data and "amptek_mca_spectrum" in run.primary.data :
+    if has_amptek_keys(ref, api_key=api_key):
         cycle = run.metadata["start"]["cycle"]
         project = run.metadata["start"]["project_name"]
         datasession = run.metadata["start"]["data_session"]

--- a/export.py
+++ b/export.py
@@ -3,16 +3,17 @@ import os, event_model
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from tiled.client import from_profile
-from prefect.blocks.system import Secret
+from tiled.client import from_uri
 import time as ttime
 
-api_key = Secret.load("tiled-smi-api-key", _sync=True).get()
-tiled_client = from_profile("nsls2", api_key=api_key)["smi"]
-tiled_client_raw = tiled_client["raw"]
 
 @task
-def export_amptek(ref):
+def get_run(uid, api_key=None):
+    return from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)["smi"]["raw"][uid]
+
+
+@task
+def export_amptek(ref, api_key=None):
     """
     Parameters
     ----------
@@ -29,8 +30,7 @@ def export_amptek(ref):
 
     ########################
 
-    run = tiled_client_raw[ref]
-
+    run = get_run(ref, api_key=api_key)
 
     if "amptek_energy_channels" in run.primary.data and "amptek_mca_spectrum" in run.primary.data :
         cycle = run.metadata["start"]["cycle"]

--- a/export.py
+++ b/export.py
@@ -3,13 +3,8 @@ import os, event_model
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from tiled.client import from_uri
 import time as ttime
-
-
-@task
-def get_run(uid, api_key=None):
-    return from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)["smi"]["raw"][uid]
+from data_validation import get_run
 
 
 @task

--- a/linker.py
+++ b/linker.py
@@ -3,15 +3,11 @@ from pathlib import Path
 from tiled.client import from_uri
 from prefect.blocks.system import Secret
 from prefect.states import Failed
+from data_validation import get_run
 
 import event_model
 import tqdm
 import shutil
-
-
-@task
-def get_run(uid, api_key=None):
-    return from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)["smi"]["raw"][uid]
 
 
 @task

--- a/linker.py
+++ b/linker.py
@@ -213,9 +213,9 @@ def get_symlink_pairs(ref, *, det_map, root_map=None, api_key=None, dry_run=Fals
 
     if len(failed) > 0:
         logger.info(f"Failed generating links {failed}")
-        success_rate = failed / (failed + linked) * 100
+        success_rate = len(failed) / (len(failed) + len(linked)) * 100
         logger.info("Success rate: {success_rate:.2f}%")
-        return
+        return Failed(message="{len(failed)} failures - {success_rate:.2f} success rate")
     elif len(linked) > 0:
         logger.info(f"Links successfully generated {linked}")
         logger.info(f"Success rate: 100%")

--- a/linker.py
+++ b/linker.py
@@ -10,7 +10,7 @@ import shutil
 
 
 @task
-def get_run(uid, api_key=api_key):
+def get_run(uid, api_key=None):
     return from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)["smi"]["raw"][uid]
 
 

--- a/linker.py
+++ b/linker.py
@@ -1,6 +1,6 @@
 from prefect import flow, task, get_run_logger
 from pathlib import Path
-from tiled.client import from_profile
+from tiled.client import from_uri
 from prefect.blocks.system import Secret
 
 import event_model

--- a/linker.py
+++ b/linker.py
@@ -7,9 +7,10 @@ import event_model
 import tqdm
 import shutil
 
-api_key = Secret.load("tiled-smi-api-key", _sync=True).get()
-tiled_client = from_profile("nsls2", api_key=api_key)["smi"]
-tiled_client_raw = tiled_client["raw"]
+
+@task
+def get_run(uid, api_key=api_key):
+    return from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)["smi"]["raw"][uid]
 
 
 @task
@@ -82,7 +83,7 @@ def do_symlinking(
 
 
 @task
-def get_symlink_pairs(ref, *, det_map, root_map=None):
+def get_symlink_pairs(ref, *, det_map, root_map=None, api_key=None):
     """
     Parameters
     ----------
@@ -114,7 +115,7 @@ def get_symlink_pairs(ref, *, det_map, root_map=None):
     ########################
 
     # hrf = db[ref]
-    hrf = tiled_client_raw[ref]
+    hrf = get_run(ref, api_key=api_key)
     for name, doc in hrf.documents():
         if name == "start":
             start_uid = doc["uid"]

--- a/linker.py
+++ b/linker.py
@@ -83,7 +83,7 @@ def do_symlinking(
 
 
 @task
-def get_symlink_pairs(ref, *, det_map, root_map=None, api_key=None):
+def get_symlink_pairs(ref, *, det_map, root_map=None, api_key=None, dry_run=False):
     """
     Parameters
     ----------
@@ -205,7 +205,11 @@ def get_symlink_pairs(ref, *, det_map, root_map=None, api_key=None):
         elif name == "stop":
             break
 
-    linked, failed = do_symlinking(links, overwrite_dest=True)
+    if not dry_run:
+        linked, failed = do_symlinking(links, overwrite_dest=True)
+    else:
+        logger.info("Dry run: not generating links")
+        return
 
     if len(failed) > 0:
         logger.info(f"Failed generating links {failed}")

--- a/linker.py
+++ b/linker.py
@@ -190,14 +190,14 @@ def get_symlink_pairs(ref, *, det_map, root_map=None, api_key=None, dry_run=Fals
                             )
                         )
 
-                        
+
                         dest_path = target_path / target_template.format(
                             det_name=det_name,
                             N=point_number * fpp + fr,
                             det_type=det_type,
                             **single_doc_data
                         ).format(**single_doc_data)
-                        
+
                         links.append(
                             (start_uid, source_path, dest_path, analysis_path)
                         )

--- a/linker.py
+++ b/linker.py
@@ -2,6 +2,7 @@ from prefect import flow, task, get_run_logger
 from pathlib import Path
 from tiled.client import from_uri
 from prefect.blocks.system import Secret
+from prefect.states import Failed
 
 import event_model
 import tqdm

--- a/linker.py
+++ b/linker.py
@@ -205,7 +205,9 @@ def get_symlink_pairs(ref, *, det_map, root_map=None, api_key=None, dry_run=Fals
     if not dry_run:
         linked, failed = do_symlinking(links, overwrite_dest=True)
     else:
-        logger.info("Dry run: not generating links")
+        logger.info("Dry run: skipped link information: ")
+        for link in links:
+            logger.info(f"UID: {link[0]} src: {link[1]} dest: {link[2]} analysis: {link[3]}")
         return
 
     if len(failed) > 0:

--- a/linker.py
+++ b/linker.py
@@ -213,8 +213,11 @@ def get_symlink_pairs(ref, *, det_map, root_map=None, api_key=None, dry_run=Fals
 
     if len(failed) > 0:
         logger.info(f"Failed generating links {failed}")
+        success_rate = failed / (failed + linked) * 100
+        logger.info("Success rate: {success_rate:.2f}%")
         return
     elif len(linked) > 0:
         logger.info(f"Links successfully generated {linked}")
+        logger.info(f"Success rate: 100%")
         return
 

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -30,7 +30,7 @@ deployments:
         volumes:
           - /nsls2/data/smi/proposals:/nsls2/data/smi/proposals
           - /nsls2/data/smi/shared/default_nb:/nsls2/data/smi/shared/default_nb
-          - /srv/prefect3_docker_worker_smi/app:/srv
+          - /srv/prefect3-docker-worker-smi/app:/srv
         container_create_kwargs:
           userns_mode: "keep-id:uid=402959,gid=402959"  # workflow-smi:workflow-smi
         auto_remove: true

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -14,7 +14,7 @@ pull:
 
 deployments:
   - name: smi-end-of-run-workflow-docker
-    version: 0.1.2
+    version: 0.1.3
     tags:
       - smi
       - main
@@ -24,15 +24,13 @@ deployments:
     schedule: {}
     work_pool:
       job_variables:
-        env:
-          TILED_SITE_PROFILES: /nsls2/software/etc/tiled/profiles
         image: ghcr.io/nsls2/smi-workflows:main
         image_pull_policy: Always
         network: slirp4netns
         volumes:
           - /nsls2/data/smi/proposals:/nsls2/data/smi/proposals
           - /nsls2/data/smi/shared/default_nb:/nsls2/data/smi/shared/default_nb
-          - /nsls2/software/etc/tiled:/nsls2/software/etc/tiled
+          - /srv/prefect3_docker_worker_smi/app:/srv
         container_create_kwargs:
           userns_mode: "keep-id:uid=402959,gid=402959"  # workflow-smi:workflow-smi
         auto_remove: true


### PR DESCRIPTION
Infrastructure updates and improvements in error handling

- dotenv - enable using a file containing the Tiled API key, instead of Prefect Blocks
- dry_run - steps towards enabling dry-running of workflows for basic testing
- from_uri - also for enabling testing workflows using Github actions, which run on remote hosts that cannot mount directories from our hosts
- 