### PR TITLE
Add slack messaging fix api key

### DIFF
--- a/data_validation.py
+++ b/data_validation.py
@@ -1,10 +1,22 @@
+import os
 from prefect import task, flow, get_run_logger
 import time as ttime
 from tiled.client import from_uri
+from dotenv import load_dotenv
+
+
+def get_api_key_from_env(api_key=None):
+    logger = get_run_logger()
+    with open("/srv/container.secret", "r") as secrets:
+        load_dotenv(stream=secrets)
+    api_key = os.environ["TILED_API_KEY"]
+    return api_key
 
 
 @task(retries=2, retry_delay_seconds=10)
 def get_run(uid, api_key=None):
+    if not api_key:
+        api_key = get_api_key_from_env()
     tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
     run = tiled_client["smi/raw"][uid]
     return run

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -1,19 +1,82 @@
 import getpass
 import os
+import traceback
+
 from prefect import task, flow, get_run_logger
 from prefect.task_runners import ConcurrentTaskRunner
-from data_validation import read_all_streams
+from dotenv import load_dotenv
+from prefect.blocks.notifications import SlackWebhook
+from prefect.context import FlowRunContext
+from prefect.settings import PREFECT_UI_URL
+
+from data_validation import read_all_streams, get_run, get_api_key_from_env
 from linker import get_symlink_pairs
 from export import export_amptek, has_amptek_keys
-from dotenv import load_dotenv
+
+CATALOG_NAME = "smi"
 
 
-def get_api_key_from_env(api_key=None):
-    logger = get_run_logger()
-    with open("/srv/container.secret", "r") as secrets:
-        load_dotenv(stream=secrets)
-    api_key = os.environ["TILED_API_KEY"]
-    return api_key
+def slack(func):
+    """
+    Send a message to mon-prefect and mon-prefect-im slack channels if the flow-run failed.
+    Send a message to mon-prefect-smi slack channel with the flow-run status.
+    Send a message to mon-bluesky slack channel if the bluesky-run failed.
+
+    NOTE: the name of this inner function is the same as the real end_of_workflow() function because
+    when the decorator is used, Prefect sees the name of this inner function as the name of
+    the flow. To keep the naming of workflows consistent, the name of this inner function had to match the expected name.
+    """
+
+    def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
+        flow_run_name = FlowRunContext.get().flow_run.dict().get("name")
+
+        # Load slack credentials that are saved in Prefect.
+        mon_prefect = SlackWebhook.load("mon-prefect")
+        mon_bluesky = SlackWebhook.load("mon-bluesky")
+        mon_prefect_smi = SlackWebhook.load("mon-prefect-smi")
+        mon_prefect_cs = SlackWebhook.load("mon-prefect-cs")
+
+        # Get the uid.
+        uid = stop_doc["run_start"]
+
+        # Get Tiled API key, if not set already
+        if not api_key:
+            api_key = get_api_key_from_env()
+
+        # Get the scan_id.
+        run = get_run(uid, api_key=api_key)
+        scan_id = run.start["scan_id"]
+
+        # Send a message to mon-bluesky if bluesky-run failed.
+        if stop_doc.get("exit_status") == "fail":
+            mon_bluesky.notify(
+                f":bangbang: {CATALOG_NAME} bluesky-run failed. (*{flow_run_name}*)\n ```run_start: {uid}\nscan_id: {scan_id}``` ```reason: {stop_doc.get('reason', 'none')}```"
+            )
+
+        try:
+            result = func(stop_doc, api_key=api_key, dry_run=dry_run)
+
+            # Send a message to mon-prefect-smi if flow-run is successful.
+            message = f":white_check_mark: {CATALOG_NAME} flow-run successful. (*{flow_run_name}*)\n ```run_start: {uid}\nscan_id: {scan_id}```"
+            mon_prefect_smi.notify(message)
+            return result
+        except Exception as e:
+            tb = traceback.format_exception_only(e)
+
+            # Send a message to mon-prefect-smi, mon-prefect if flow-run failed.
+            message = f":bangbang: {CATALOG_NAME} flow-run failed. (*{flow_run_name}*)\n ```run_start: {uid}\nscan_id: {scan_id}``` ```{tb[-1]}```"
+            mon_prefect.notify(message)
+            mon_prefect_smi.notify(message)
+            flow_run = FlowRunContext.get().flow_run
+            # Add link to flow-run for the message to mon-prefect-cs.
+            program_message = (
+                f":bangbang: {CATALOG_NAME} flow-run failed. <https://{PREFECT_UI_URL.value()}/flow-runs/"
+                + f"flow-run/{flow_run.id}|the flow run link> (*{flow_run_name}*)\n ```run_start: {uid}\nscan_id: {scan_id}``` ```{tb[-1]}```"
+            )
+            mon_prefect_cs.notify(program_message)
+            raise
+
+    return end_of_run_workflow
 
 
 @task
@@ -23,6 +86,7 @@ def log_completion():
 
 
 @flow(task_runner=ConcurrentTaskRunner())
+@slack
 def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
     logger = get_run_logger()
     uid = stop_doc["run_start"]

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -90,8 +90,6 @@ def log_completion():
 def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
     logger = get_run_logger()
     uid = stop_doc["run_start"]
-    if not api_key:
-        api_key = get_api_key_from_env(api_key=None)
     logger.info(f"effective user: {getpass.getuser()}")
 
     # Launch validation and linker concurrently.

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -9,7 +9,7 @@ from prefect.blocks.notifications import SlackWebhook
 from prefect.context import FlowRunContext
 from prefect.settings import PREFECT_UI_URL
 
-from data_validation import read_all_streams, get_run, get_api_key_from_env
+from data_validation import read_all_streams, get_run
 from linker import get_symlink_pairs
 from export import export_amptek, has_amptek_keys
 
@@ -38,10 +38,6 @@ def slack(func):
 
         # Get the uid.
         uid = stop_doc["run_start"]
-
-        # Get Tiled API key, if not set already
-        if not api_key:
-            api_key = get_api_key_from_env()
 
         # Get the scan_id.
         run = get_run(uid, api_key=api_key)

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -70,7 +70,7 @@ def slack(func):
             flow_run = FlowRunContext.get().flow_run
             # Add link to flow-run for the message to mon-prefect-cs.
             program_message = (
-                f":bangbang: {CATALOG_NAME} flow-run failed. <https://{PREFECT_UI_URL.value()}/flow-runs/"
+                f":bangbang: {CATALOG_NAME} flow-run failed. <{PREFECT_UI_URL.value()}/flow-runs/"
                 + f"flow-run/{flow_run.id}|the flow run link> (*{flow_run_name}*)\n ```run_start: {uid}\nscan_id: {scan_id}``` ```{tb[-1]}```"
             )
             mon_prefect_cs.notify(program_message)

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -18,7 +18,7 @@ CATALOG_NAME = "smi"
 
 def slack(func):
     """
-    Send a message to mon-prefect and mon-prefect-im slack channels if the flow-run failed.
+    Send a message to mon-prefect and mon-prefect-cs slack channels if the flow-run failed.
     Send a message to mon-prefect-smi slack channel with the flow-run status.
     Send a message to mon-bluesky slack channel if the bluesky-run failed.
 


### PR DESCRIPTION
 * fix API key retrieval to be done within get_run() to prevent the value read from file from being visible as a parameter for the called functions
 * add Slack messaging - mon-prefect, mon-prefect-cs for failures, mon-prefect-smi for successes and failures for workflow runs. mon-prefect-cs has a link for easy retry